### PR TITLE
Checks for valid table blocks using tengo

### DIFF
--- a/.vale/fixtures/AsciiDoc/ValidTableBlocks/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/ValidTableBlocks/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `ValidConditions` rule
+StylesPath = ../../../styles
+MinAlertLevel = error
+[*.adoc]
+AsciiDoc.ValidTableBlocks = YES

--- a/.vale/fixtures/AsciiDoc/ValidTableBlocks/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidTableBlocks/testinvalid.adoc
@@ -9,9 +9,11 @@
 |Cell 2, row 1
 |Cell 3, row 1
 
+
 //vale-fixture
 .Table two
-[options="header"]
+[options="header"]test
+test
 |====
 |Column Title|Column Title
 |content|content

--- a/.vale/fixtures/AsciiDoc/ValidTableBlocks/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidTableBlocks/testinvalid.adoc
@@ -1,0 +1,33 @@
+//vale-fixture
+.Table one
+[Attributes]
+|===
+|Header column 1 |Header column 2 |Header column 3
+
+|Cell 1, row 1
+|Cell 2, row 1
+|Cell 3, row 1
+
+//vale-fixture
+.Table two
+[options="header"]
+|====
+|Column Title|Column Title
+|content|content
+|====
+
+//vale-fixture
+.Table three
+[options="header"]
+|====
+|Column Title|Column Title|Column Title
+|content|content|content
+|====
+|====
+|====
+[source,yaml,options="nowrap",role="white-space-pre"]
+----
+
+
+----
+

--- a/.vale/fixtures/AsciiDoc/ValidTableBlocks/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidTableBlocks/testinvalid.adoc
@@ -1,9 +1,10 @@
+//This will only throw an error if there are an odd number of table delimiters. If two tables are missing 1 delimiter tag, then the tables will be bad but this script counts and even number and so won't throw an error. 
+
 //vale-fixture
 .Table one
 [Attributes]
 |===
 |Header column 1 |Header column 2 |Header column 3
-
 |Cell 1, row 1
 |Cell 2, row 1
 |Cell 3, row 1
@@ -23,11 +24,6 @@
 |Column Title|Column Title|Column Title
 |content|content|content
 |====
-|====
-|====
-[source,yaml,options="nowrap",role="white-space-pre"]
-----
 
 
-----
 

--- a/.vale/fixtures/AsciiDoc/ValidTableBlocks/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidTableBlocks/testvalid.adoc
@@ -1,0 +1,42 @@
+//vale-fixture
+ifdef::env-github[]
+This content is for GitHub only.
+endif::env-github[]
+
+//vale-fixture
+ifndef::env-github[]
+This content is for GitHub only.
+
+So much content in this section, I'd get confused.
+endif::[]
+
+//vale-fixture
+ifdef::revnumber[]
+This document has a version number of {revnumber}.
+endif::[]
+
+//vale-fixture - doesn't work
+//ifndef::profile-production,env-site[Not shown if profile-production or env-site is set.]
+
+//vale-fixture
+ifndef::profile-staging+env-site[Not shown if profile-staging and env-site are set.]
+
+//vale-fixture
+ifeval::[2 > 1]
+Some text!
+endif::[]
+
+//vale-fixture
+ifeval::["{backend}" == "html5"]
+Some text!
+endif::[]
+
+//vale-fixture
+ifeval::[{sectnumlevels} == 3]
+Some text!
+endif::[]
+
+//vale-fixture
+ifeval::["{docname}{outfilesuffix}" == "main.html"]
+Some text!
+endif::[]

--- a/.vale/fixtures/AsciiDoc/ValidTableBlocks/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidTableBlocks/testvalid.adoc
@@ -1,42 +1,26 @@
 //vale-fixture
-ifdef::env-github[]
-This content is for GitHub only.
-endif::env-github[]
+.Table one
+[Attributes]
+|===
+|Header column 1 |Header column 2 |Header column 3
+
+|Cell 1, row 1
+|Cell 2, row 1
+|Cell 3, row 1
+|===
 
 //vale-fixture
-ifndef::env-github[]
-This content is for GitHub only.
-
-So much content in this section, I'd get confused.
-endif::[]
-
-//vale-fixture
-ifdef::revnumber[]
-This document has a version number of {revnumber}.
-endif::[]
-
-//vale-fixture - doesn't work
-//ifndef::profile-production,env-site[Not shown if profile-production or env-site is set.]
+.Table two
+[options="header"]
+|====
+|Column Title|Column Title
+|content|content
+|====
 
 //vale-fixture
-ifndef::profile-staging+env-site[Not shown if profile-staging and env-site are set.]
-
-//vale-fixture
-ifeval::[2 > 1]
-Some text!
-endif::[]
-
-//vale-fixture
-ifeval::["{backend}" == "html5"]
-Some text!
-endif::[]
-
-//vale-fixture
-ifeval::[{sectnumlevels} == 3]
-Some text!
-endif::[]
-
-//vale-fixture
-ifeval::["{docname}{outfilesuffix}" == "main.html"]
-Some text!
-endif::[]
+.Table three
+[options="header"]
+|====
+|Column Title|Column Title|Column Title
+|content|content|content
+|====

--- a/.vale/styles/AsciiDoc/ValidTableBlocks.tengo
+++ b/.vale/styles/AsciiDoc/ValidTableBlocks.tengo
@@ -19,21 +19,17 @@ counter := 0
 for line in text.split(scope, "\n") {
   if text.re_match(tbl_delimiter_regex, line) {
     counter ++
-    start := text.index(scope, line)
-    matches = append(matches, {begin: start, end: start + len(line)})
-    fmt.println("Delimiter matches: ",len(matches))
-    fmt.println(line)
+    
   } }
 fmt.println(counter)
 fmt.println(counter % 2)
 if counter % 2 == 1{
   fmt.println("We got an odd number of delimiters here")
+  matches = append(matches, {begin: 0, end: len(scope)})
+  fmt.println(matches)
 } else{
   fmt.println("Delimiters lookin good")
+  fmt.println(matches)
 }
 
-if len(matches) == 0 {
-  fmt.println(matches)
-} else {
-  fmt.println(matches) 
-}
+

--- a/.vale/styles/AsciiDoc/ValidTableBlocks.tengo
+++ b/.vale/styles/AsciiDoc/ValidTableBlocks.tengo
@@ -1,0 +1,39 @@
+/*
+    Tengo Language
+    $ tengo ValidTableBlocks.tengo <asciidoc_file_to_validate>
+*/
+
+fmt := import("fmt")
+os := import("os")
+text := import("text")
+
+input := os.args()
+//vale gets the file as scope when it runs
+scope := os.read_file(input[2])
+matches := []
+
+tbl_delimiter_regex := "\\|==="
+counter := 0
+
+
+for line in text.split(scope, "\n") {
+  if text.re_match(tbl_delimiter_regex, line) {
+    counter ++
+    start := text.index(scope, line)
+    matches = append(matches, {begin: start, end: start + len(line)})
+    fmt.println("Delimiter matches: ",len(matches))
+    fmt.println(line)
+  } }
+fmt.println(counter)
+fmt.println(counter % 2)
+if counter % 2 == 1{
+  fmt.println("We got an odd number of delimiters here")
+} else{
+  fmt.println("Delimiters lookin good")
+}
+
+if len(matches) == 0 {
+  fmt.println(matches)
+} else {
+  fmt.println(matches) 
+}

--- a/.vale/styles/AsciiDoc/ValidTableBlocks.yml
+++ b/.vale/styles/AsciiDoc/ValidTableBlocks.yml
@@ -2,7 +2,7 @@
 extends: script
 ignorecase: true
 level: error
-message: "Check that table has a closing table code block TEST."
+message: "There are an odd number of table delimiter blocks in the module, check you have opening and closing delimiters (|===) for each table."
 link: https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/
 scope: raw
 script: |
@@ -15,22 +15,9 @@ script: |
   for line in text.split(scope, "\n") {
     if text.re_match(tbl_delimiter_regex, line) {
       counter ++
-      start := text.index(scope, line)
-      matches = append(matches, {begin: start, end: start + len(line)})
-      fmt.println("Delimiter matches: ",len(matches))
-      fmt.println(line)
-    }
-  }
-  fmt.println(counter)
-  fmt.println(counter % 2)
+      }
+      }
+  
   if counter % 2 == 1{
-    fmt.println("We got an odd number of delimiters here")
-    } else{
-      fmt.println("Delimiters lookin good")
-      }
-
-  if len(matches) == 0 {
-    fmt.println(matches)
-    } else{
-      fmt.println(matches)
-      }
+    matches = append(matches, {begin: 0, end: len(scope)})
+    } 

--- a/.vale/styles/AsciiDoc/ValidTableBlocks.yml
+++ b/.vale/styles/AsciiDoc/ValidTableBlocks.yml
@@ -1,0 +1,36 @@
+---
+extends: script
+ignorecase: true
+level: error
+message: "Check that table has a closing table code block TEST."
+link: https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/
+scope: raw
+script: |
+  text := import("text")
+  
+  matches := []
+
+  tbl_delimiter_regex := "\\|==="
+  counter := 0
+  for line in text.split(scope, "\n") {
+    if text.re_match(tbl_delimiter_regex, line) {
+      counter ++
+      start := text.index(scope, line)
+      matches = append(matches, {begin: start, end: start + len(line)})
+      fmt.println("Delimiter matches: ",len(matches))
+      fmt.println(line)
+    }
+  }
+  fmt.println(counter)
+  fmt.println(counter % 2)
+  if counter % 2 == 1{
+    fmt.println("We got an odd number of delimiters here")
+    } else{
+      fmt.println("Delimiters lookin good")
+      }
+
+  if len(matches) == 0 {
+    fmt.println(matches)
+    } else{
+      fmt.println(matches)
+      }

--- a/.vale/styles/AsciiDoc/ValidTableBlocks2.tengo
+++ b/.vale/styles/AsciiDoc/ValidTableBlocks2.tengo
@@ -1,0 +1,47 @@
+/*
+    Tengo Language
+    $ tengo ValidTableBlocks.tengo <asciidoc_file_to_validate>
+*/
+
+fmt := import("fmt")
+os := import("os")
+text := import("text")
+
+input := os.args()
+//vale gets the file as scope when it runs
+scope := os.read_file(input[2])
+matches := []
+
+tbl_start_regex := "\\[*\\]"
+tbl_start_tags := "\\|={3,4}"
+//tbl_end_regex := "\\|={3,4}"
+//counter := 0
+
+
+//conditional to determine if iterator should look at line
+should_print := false
+
+for line in text.split(scope, "\n") {
+  if should_print{
+    fmt.println("The line following square brackets is: ",line)
+    
+    //Set should_print to false until other if statement finds "[*]"
+    should_print = false
+    
+    //Check if line follow square brackets has table tags
+    if text.re_match(tbl_start_tags, line){
+      fmt.println("Line contains table tags")
+      //Then use logic from Aidan's script?
+    }
+
+  }
+  //Check if line has square brackets that may indicate a table
+  if text.re_match(tbl_start_regex, line) {
+    fmt.println(line)
+    //Change should print to true so first if statement runs to check next line
+    should_print = true
+  }
+}
+
+
+


### PR DESCRIPTION
This counts the number of table delimiters "|====" in a module and throws an error if it finds an uneven number. However, if two table are missing a single delimiter each, then the count will be even and the script passes, even though it shouldn't....