### PR TITLE
Add GH action to validate Vale rules in PRs

### DIFF
--- a/.github/workflows/validate-on-pull.yml
+++ b/.github/workflows/validate-on-pull.yml
@@ -1,0 +1,19 @@
+---
+name: Verify Vale test fixtures
+on:
+  - pull_request
+jobs:
+  validate-rules:
+    name: Validate rules
+    runs-on: ubuntu-latest
+    #antora-for-modular-docs:main includes vale
+    container: quay.io/antoraformodulardocs/antora-for-modular-docs:main
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # enable git diff and building many branches
+      - name: Validate Vale rules
+        id: validate-rules
+        run: scripts/validate-vale-rules.sh

--- a/.vale/fixtures/AsciiDoc/IdHasContextVariable/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/IdHasContextVariable/testinvalid.adoc
@@ -2,5 +2,4 @@
 [id="cli-basic-commands_"]
 
 //vale-fixture
-// Do we have multiple IDs in the same module?
 [id="another-id-in-the-same-module-also-gets-flagged"]

--- a/scripts/validate-vale-rules.sh
+++ b/scripts/validate-vale-rules.sh
@@ -8,32 +8,32 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 # Fail on errors
+
 set -e
 
 Rule() {
     DIR=".vale/fixtures/AsciiDoc/$RULE"
     echo $DIR
     VALIDALERTSCOUNT="$(vale --config="$DIR/.vale.ini" --no-exit --output=line "$DIR/testvalid.adoc" | wc -l)"
-    INVALIDALERTS="$(vale --config="$DIR/.vale.ini" --no-exit --output=line "$DIR/testinvalid.adoc" | wc -l)"
-    #echo "Vale ALERTS: $INVALIDALERTS"
+    INVALIDALERTSCOUNT="$(vale --config="$DIR/.vale.ini" --no-exit --output=line "$DIR/testinvalid.adoc" | wc -l)"
     INVALIDLINES="$(grep -c "//vale-fixture" "$DIR/testinvalid.adoc" || true)"
     #echo "INVALID LINES: $INVALIDLINES"
-    INVALIDGAP=$(($INVALIDLINES - $INVALIDALERTS))
+    #echo "Vale ALERTS: $INVALIDALERTSCOUNT"
+    #INVALIDLINES="$(grep -cve '.+' "$DIR/testinvalid.adoc" || true)"
+    INVALIDGAP=$(($INVALIDALERTSCOUNT - $INVALIDLINES))
     if [ "$VALIDALERTSCOUNT" -gt 0 ]
     then
-    #    echo "INVALID LINES: $INVALIDLINES"
-    #    echo "Vale ALERTS: $INVALIDALERTS"
-        echo "ERROR: $VALIDALERTSCOUNT in .vale/fixtures/AsciiDoc/$RULE/testvalid.adoc for .vale/styles/AsciiDoc/$RULE.yml"
+        echo "$VALIDALERTSCOUNT ERROR(s) in .vale/fixtures/AsciiDoc/$RULE/testvalid.adoc for .vale/styles/AsciiDoc/$RULE.yml"
         TOTAL=$(( TOTAL + VALIDALERTSCOUNT ))
     fi
     if [ $INVALIDGAP -gt 0 ]
     then
-        echo "ERROR: $INVALIDGAP in .vale/fixtures/AsciiDoc/$RULE/testinvalid.adoc / .vale/styles/AsciiDoc/$RULE.yml"
+        echo "$INVALIDGAP ERROR(s) in .vale/fixtures/AsciiDoc/$RULE/testinvalid.adoc / .vale/styles/AsciiDoc/$RULE.yml"
         TOTAL=$(( TOTAL + INVALIDGAP ))
     fi
 }
 
-# This scripts runs the  suite for each rule in the `RedHat` style.
+# This scripts runs the  suite for each rule in the `AsciiDoc` style.
 TOTAL=0
 for RULE in $(find .vale/styles/AsciiDoc/ -name '*.yml' | cut -d/ -f 4 | cut -d. -f1 | sort)
 do  


### PR DESCRIPTION
run scripts/validate-vale-rules.sh on PR push.

* For invalid.adoc files, If the number of errors != the number of `//vale-fixture` strings, a validation error is thrown.
* If any error is found in a valid.adoc file, an error is found.