### PR TITLE
WIP - refactor module specific rules

### DIFF
--- a/.vale/fixtures/AsciiDoc/NoXrefInModules/modules/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/NoXrefInModules/modules/.vale.ini
@@ -1,5 +1,5 @@
 ; Vale configuration file to test the `NoXrefInModules` rule
-StylesPath = ../../../styles
+StylesPath = ../../../../styles
 MinAlertLevel = suggestion
 [*.adoc]
 AsciiDoc.NoXrefInModules = YES

--- a/.vale/fixtures/AsciiDoc/NoXrefInModules/modules/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/NoXrefInModules/modules/testinvalid.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * blah
+
+:_content-type: CONCEPT
+[id="REPLACE_ME_WITH_ID_{context}"]
+= REPLACE_ME_WITH_TITLE
+
+//vale-fixture
+xref:../rosa_getting_started/rosa-getting-started.adoc#rosa-getting-started[Getting started with {product-title}]

--- a/.vale/fixtures/AsciiDoc/NoXrefInModules/modules/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/NoXrefInModules/modules/testvalid.adoc
@@ -1,2 +1,9 @@
+:_content-type: ASSEMBLY
+[id="REPLACE_ME_WITH_ID"]
+= REPLACE_ME_WITH_TITLE
+:context: REPLACE_ME_WITH_CONTEXT
+
+toc::[]
+
 //vale-fixture
 xref:../rosa_getting_started/rosa-getting-started.adoc#rosa-getting-started[Getting started with {product-title}]

--- a/.vale/fixtures/AsciiDoc/NoXrefInModules/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/NoXrefInModules/testvalid.adoc
@@ -1,1 +1,0 @@
-No xrefs here!

--- a/.vale/fixtures/AsciiDoc/ValidCodeBlocks/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidCodeBlocks/testinvalid.adoc
@@ -1,6 +1,19 @@
 //vale-fixture
 Here is a code block:
 
+.REPLACE_WITH_TABLE_TITLE
+[cols=2*, width="40%", options="header"]
+|====
+|Firefox
+|Web Browser
+
+|Ruby
+|Programming Language
+
+|TorqueBox
+|Application Server
+
+
 [source,terminal]
 ----
 $ pwd
@@ -11,7 +24,6 @@ Here is a another code block:
 [source,terminal]
 ----
 $ pwd
-----
 
 Here is a code block:
 
@@ -19,8 +31,8 @@ Here is a code block:
 ----
 ---
 apiVersion: 4.11
-
 Some text.
+----
 
 Here is a code block:
 

--- a/.vale/fixtures/AsciiDoc/ValidCodeBlocks/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ValidCodeBlocks/testinvalid.adoc
@@ -1,25 +1,10 @@
 //vale-fixture
 Here is a code block:
 
-.REPLACE_WITH_TABLE_TITLE
-[cols=2*, width="40%", options="header"]
-|====
-|Firefox
-|Web Browser
-
-|Ruby
-|Programming Language
-
-|TorqueBox
-|Application Server
-
-
 [source,terminal]
 ----
 $ pwd
 ----
-
-Here is a another code block:
 
 [source,terminal]
 ----
@@ -40,6 +25,5 @@ Here is a code block:
 ----
 ---
 apiVersion: 4.11
-----
-
 Some text.
+----

--- a/.vale/styles/AsciiDoc/NoXrefInModules.yml
+++ b/.vale/styles/AsciiDoc/NoXrefInModules.yml
@@ -1,9 +1,24 @@
 ---
-extends: existence
-scope: raw
+extends: script
 ignorecase: true
 level: error
-link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#links-hyperlinks-and-cross-references
 message: "Do not include xrefs in modules, only assemblies."
-tokens:
-  - 'xref:(.*)(\.adoc)#(.*)'
+link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#links-hyperlinks-and-cross-references
+scope: raw
+script: |
+  text := import("text")
+
+  matches := []
+  xref_regex := "xref:(.*)(\\.adoc)#(.*)"
+  content_type_regex := "^:_content-type:\\s(CONCEPT|PROCEDURE|REFERENCE)"
+  module := false
+
+  //if the file has a module content-type, flag the xref error
+  for line in text.split(scope, "\n") {
+    if text.re_match(content_type_regex, line) {
+      module = true
+  } else if text.re_match(xref_regex, line) && module == true {
+      start := text.index(scope, line)
+      matches = append(matches, {begin: start, end: start + len(line)})
+    }
+  }

--- a/.vale/styles/AsciiDoc/ValidCodeBlocks.yml
+++ b/.vale/styles/AsciiDoc/ValidCodeBlocks.yml
@@ -2,35 +2,23 @@
 extends: script
 ignorecase: true
 level: error
-message: "One or more AsciiDoc code blocks is open or there is a missing source attributes block."
+message: "Unterminated AsciiDoc listing block found in file."
 link: https://docs.asciidoctor.org/asciidoc/latest/verbatim/source-blocks/
 scope: raw
 script: |
   text := import("text")
 
   matches := []
-  lines := []
   codeblock_delim_regex := "^-{4,}"
-  source_block_regex := "^\\[.*\\]"
-  line_num := 0
   count := 0
 
-  //create a one-indexed array called lines with entries for each line in the scope
   for line in text.split(scope, "\n") {
-    line_num ++
-    lines = append(lines, {"line": line_num, "text": line})
-  }
-
-  for line in text.split(scope, "\n") {
-    count ++
-    //check for codeblock delim and sourceblock immediately preceding it
     if text.re_match(codeblock_delim_regex, line) {
-      if text.re_match(source_block_regex, lines[count-2].text) {
-        start := text.index(scope, line)
-        matches = append(matches, {begin: start, end: start + len(line)})
-      } else if len(matches) > 0 {
-        //remove the most recently added match
-        matches = matches[:len(matches)-1]
-      }
+      count += 1
+      start := text.index(scope, line)
+      matches = append(matches, {begin: start, end: start + len(line)}) 
+    } else if count > 1 {
+      count = 0 // code block is closed, reset the count
+      matches = []
     }
   }

--- a/.vale/styles/AsciiDoc/ValidCodeBlocks.yml
+++ b/.vale/styles/AsciiDoc/ValidCodeBlocks.yml
@@ -9,19 +9,28 @@ script: |
   text := import("text")
 
   matches := []
+  lines := []
   codeblock_delim_regex := "^-{4,}"
-  source_block_regex := "^\\[(source|subs|role).*\\]"
-  sources_blocks := 0
+  source_block_regex := "^\\[.*\\]"
+  line_num := 0
+  count := 0
 
+  //create a one-indexed array called lines with entries for each line in the scope
   for line in text.split(scope, "\n") {
-    if text.re_match(codeblock_delim_regex, line){
-      start := text.index(scope, line)
-      matches = append(matches, {begin: start, end: start + len(line)})  
-    } else if text.re_match(source_block_regex, line){
-      sources_blocks ++
-    }
+    line_num ++
+    lines = append(lines, {"line": line_num, "text": line})
   }
 
-  if len(matches) / 2 == sources_blocks {
-    matches = []
+  for line in text.split(scope, "\n") {
+    count ++
+    //check for codeblock delim and sourceblock immediately preceding it
+    if text.re_match(codeblock_delim_regex, line) {
+      if text.re_match(source_block_regex, lines[count-2].text) {
+        start := text.index(scope, line)
+        matches = append(matches, {begin: start, end: start + len(line)})
+      } else if len(matches) > 0 {
+        //remove the most recently added match
+        matches = matches[:len(matches)-1]
+      }
+    }
   }

--- a/scripts/DocumentScopeRule.tengo
+++ b/scripts/DocumentScopeRule.tengo
@@ -1,0 +1,27 @@
+/*
+    Tengo Language
+    $ tengo DocumentScopeRule.tengo <asciidoc_file_to_validate>
+*/
+
+fmt := import("fmt")
+os := import("os")
+input := os.args()
+scope := os.read_file(input[2])
+
+text := import("text")
+lines := []
+line_num := 0
+xref_regex := "xref:(.*)(\\.adoc)#(.*)"
+
+//create a one-indexed array called lines with entries for each line in the scope
+for line in text.split(scope, "\n") {
+    line_num ++
+    lines = append(lines, {"line": line_num, "text": line})
+}
+
+for item in lines {
+  if text.re_match(xref_regex, item.text) {
+    //this is the line number with the match
+    fmt.println(item.line)
+  }
+}

--- a/scripts/MatchingListingBlockBraces.tengo
+++ b/scripts/MatchingListingBlockBraces.tengo
@@ -1,6 +1,8 @@
 /*
 Tengo Language
-$ tengo ValidCodeBlocks.tengo <asciidoc_file_to_validate>
+$ tengo MatchingListingBlockBraces.tengo <asciidoc_file_to_validate>
+
+TODO: check for unmatched listing block braces
 */
 
 fmt := import("fmt")
@@ -19,7 +21,7 @@ for line in text.split(scope, "\n") {
     count += 1
     start := text.index(scope, line)
     matches = append(matches, {begin: start, end: start + len(line)}) 
-  } else if count > 1 {
+  } else if count == 2 {
     count = 0 // code block is closed, reset the count
     matches = []
   }

--- a/scripts/NoXrefInModules.tengo
+++ b/scripts/NoXrefInModules.tengo
@@ -1,0 +1,28 @@
+/*
+    Tengo Language
+    $ tengo NoXrefInModules.tengo <asciidoc_file_to_validate>
+*/
+
+fmt := import("fmt")
+os := import("os")
+text := import("text")
+
+input := os.args()
+scope := os.read_file(input[2])
+
+matches := []
+xref_regex := "xref:(.*)(\\.adoc)#(.*)"
+content_type_regex := "^:_content-type:\\s(CONCEPT|PROCEDURE|REFERENCE)"
+module := false
+
+//if the file has a module content-type, flag the xref error
+for line in text.split(scope, "\n") {
+  if text.re_match(content_type_regex, line) {
+    module = true
+} else if text.re_match(xref_regex, line) && module == true {
+    start := text.index(scope, line)
+    matches = append(matches, {begin: start, end: start + len(line)})
+  }
+}
+
+fmt.println(matches)

--- a/scripts/ValidCodeBlocks.tengo
+++ b/scripts/ValidCodeBlocks.tengo
@@ -1,6 +1,6 @@
 /*
-    Tengo Language
-    $ tengo ValidCodeBlocks.tengo <asciidoc_file_to_validate>
+Tengo Language
+$ tengo ValidCodeBlocks.tengo <asciidoc_file_to_validate>
 */
 
 fmt := import("fmt")
@@ -11,21 +11,30 @@ input := os.args()
 scope := os.read_file(input[2])
 
 matches := []
+lines := []
 codeblock_delim_regex := "^-{4,}"
-source_block_regex := "^\\[(source|subs|role).*\\]"
-sources_blocks := 0
+source_block_regex := "^\\[.*\\]"
+line_num := 0
+count := 0
 
+//create a one-indexed array called lines with entries for each line in the scope
 for line in text.split(scope, "\n") {
-  if text.re_match(codeblock_delim_regex, line){
-    start := text.index(scope, line)
-    matches = append(matches, {begin: start, end: start + len(line)})  
-  } else if text.re_match(source_block_regex, line){
-    sources_blocks ++
-  }
+  line_num ++
+  lines = append(lines, {"line": line_num, "text": line})
 }
 
-if len(matches) / 2 == sources_blocks {
-  matches = []
+for line in text.split(scope, "\n") {
+  count ++
+  //check for codeblock delim and sourceblock immediately preceding it
+  if text.re_match(codeblock_delim_regex, line) {
+    if text.re_match(source_block_regex, lines[count-2].text) {
+      start := text.index(scope, line)
+      matches = append(matches, {begin: start, end: start + len(line)})
+    } else if len(matches) > 0 {
+      //remove the most recently added match
+      matches = matches[:len(matches)-1]
+    }
+  }
 }
 
 fmt.println(matches)


### PR DESCRIPTION
Vale scripts only have access to the tengo text lib. https://vale.sh/docs/topics/styles/#script 

This PR shows an example of creating a rule that hangs off `:_content-type: CONCEPT|REFERENCE|PROCEDURE` attributes. 