### PR TITLE
Adding non-sequential numbered callout rule

### DIFF
--- a/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `SequentialNumberedCallouts` rule
+StylesPath = ../../../styles
+MinAlertLevel = error
+[*.adoc]
+AsciiDoc.SequentialNumberedCallouts = YES

--- a/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testinvalid.adoc
@@ -1,0 +1,31 @@
+[source,ruby]
+----
+require 'sinatra' <1>
+get '/hi' do <2>
+require 'sinatra' <3>
+get '/hi' do <4>
+hi there <5>
+poop <6>
+require 'sinatra'
+
+get '/hi' do <7> <8>
+  "Hello World!"
+----
+//vale-fixture
+<1> text
+<2> More text
+<3> More text again
+<5> Some text
+<6> Again, some text
+<7> Moar text
+<8> Again, some more text
+
+//vale-fixture
+[source,ruby]
+----
+require 'sinatra' <1>
+get '/hi' do <3>
+get '/hi' do <4>
+----
+<1> Test
+<2> Test

--- a/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testvalid.adoc
@@ -1,0 +1,12 @@
+//vale-fixture
+[source,ruby]
+----
+require 'sinatra' <1>
+
+get '/hi' do <2> <3>
+  "Hello World!"
+end
+----
+<1> Library import
+<2> URL mapping
+<3> Response block

--- a/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
@@ -1,0 +1,39 @@
+---
+extends: script
+ignorecase: true
+message: "Numbered callout does not follow sequentially."
+level: error
+link: https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/
+scope: raw
+script: |
+  text := import("text")
+  matches := []
+
+  prev_num := 0
+  numbered_callout_regex := "<(\\d+)>"
+  listingblock_delim_regex := "^-{4,}"
+
+  for line in text.split(scope, "\n") {
+    //reset count if we hit a listing block delimiter 
+    if text.re_match(listingblock_delim_regex, line) {
+      prev_num = 0
+    }
+
+    if text.re_match(numbered_callout_regex, line) {
+      callout := text.re_find("<(\\d+)>", line)
+      for key, value in callout {
+        //trim angle brackets from string
+        trimmed := callout[key][0]["text"]
+        trimmed = text.trim_prefix(trimmed, "<")
+        trimmed = text.trim_suffix(trimmed, ">")
+        //cast string > int
+        num := text.atoi(trimmed)
+        //start counting
+        if num != prev_num+1 {
+          start := text.index(scope, line)
+          matches = append(matches, {begin: start, end: start + len(line)}) 
+        }
+        prev_num = num
+      }
+    }
+  }

--- a/scripts/SequentialNumberedCallouts.tengo
+++ b/scripts/SequentialNumberedCallouts.tengo
@@ -1,0 +1,48 @@
+/*
+    Tengo Language
+    Checks that callouts are sequential 
+    $ tengo SequentialNumberedCallouts.tengo <asciidoc_file_to_validate>
+*/
+
+fmt := import("fmt")
+os := import("os")
+text := import("text")
+
+input := os.args()
+scope := os.read_file(input[2])
+matches := []
+
+prev_num := 0
+numbered_callout_regex := "<(\\d+)>"
+listingblock_delim_regex := "^-{4,}"
+
+for line in text.split(scope, "\n") {
+  //reset count if we hit a listing block delimiter 
+  if text.re_match(listingblock_delim_regex, line) {
+    prev_num = 0
+  }
+
+  if text.re_match(numbered_callout_regex, line) {
+    callout := text.re_find("<(\\d+)>", line)
+    for key, value in callout {
+      //trim angle brackets from string
+      trimmed := callout[key][0]["text"]
+      trimmed = text.trim_prefix(trimmed, "<")
+      trimmed = text.trim_suffix(trimmed, ">")
+      //cast string > int
+      num := text.atoi(trimmed)
+      //start counting
+      if num != prev_num+1 {
+        start := text.index(scope, line)
+        matches = append(matches, {begin: start, end: start + len(line)}) 
+      }
+      prev_num = num
+    }
+  }
+}
+
+if len(matches) == 0 {
+  fmt.println("Callouts are sequential")
+} else {
+  fmt.println(matches) 
+}


### PR DESCRIPTION
Adds numbered callout rule. Rule fires when a callout sequence (either inside or outside a listing block) is not sequential. 

* Counts numbered callouts only.

![image](https://user-images.githubusercontent.com/74046732/226342138-a769655e-aa9d-4bbb-a0aa-c9a202cf43bc.png)
