### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
           echo $GITHUB_RUN_NUMBER > version.txt
           zip -r AsciiDoc.zip AsciiDoc
           zip -r OpenShiftAsciiDoc.zip OpenShiftAsciiDoc
-          gh release create v$GITHUB_RUN_NUMBER 'AsciiDoc.zip' 'OpenShiftAsciiDoc.zip'
+          gh release create AsciiDoc_v$GITHUB_RUN_NUMBER 'AsciiDoc.zip' 
+          gh release create OpenShiftAsciiDoc_v$GITHUB_RUN_NUMBER 'OpenShiftAsciiDoc.zip'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Current workflow gives us: 

https://github.com/rohennes/vale-asciidoc/releases/download/v80/AsciiDoc.zip
https://github.com/rohennes/vale-asciidoc/releases/download/v80/OpenShiftAsciiDoc.zip

When we unzip, we get: `AsciiDoc/AsciiDoc/*.yml` We should get: `AsciiDoc/*.yml`