### PR TITLE
Matching numbered callouts

### DIFF
--- a/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `SequentialNumberedCallouts` rule
+StylesPath = ../../../styles
+MinAlertLevel = error
+[*.adoc]
+AsciiDoc.MatchingNumberedCallouts = YES

--- a/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/testinvalid.adoc
@@ -1,0 +1,20 @@
+//vale-fixture
+[source,ruby]
+----
+require 'frank' <1>
+get '/hihi' <2> <3>
+----
+<1> text
+<2> More text
+<3> More text again
+<4> Again, more text
+
+//vale-fixture
+[source,ruby]
+----
+require 'frankie' <1>
+get '/hihihi' <2>
+----
+<1> text!
+<2> More text!
+<3> More text again!

--- a/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/testvalid.adoc
@@ -1,0 +1,12 @@
+//vale-fixture
+[source,ruby]
+----
+require 'sinatra' <1>
+
+get '/hi' do <2> <3>
+  "Hello World!"
+end
+----
+<1> Library import
+<2> URL mapping
+<3> Response block

--- a/.vale/styles/AsciiDoc/MatchingNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/MatchingNumberedCallouts.yml
@@ -1,0 +1,41 @@
+---
+extends: script
+ignorecase: true
+message: "Missing numbered callout."
+level: error
+link: https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/
+scope: raw
+script: |
+  text := import("text")
+  matches := []
+
+  num_codeblock_callouts := 0
+  num_callouts := 0
+  codeblock_callout_regex := ".+( <\\d+>)+"
+  callout_regex := "^<(\\d+)>"
+
+  for line in text.split(scope, "\n") {
+    if text.re_match(codeblock_callout_regex, line) {
+      //restart for new listingblock
+      num_callouts = 0
+      //account for lines with multiple callouts
+      for i := 1; i < len(line); i++ {
+        //text.count must be str, not regex
+        str := "<" + i + ">"
+        num_callouts_in_line := text.count(line, str)
+        num_codeblock_callouts += num_callouts_in_line
+      }
+    }
+
+    if text.re_match(callout_regex, line) {
+      num_callouts++
+      if num_callouts > num_codeblock_callouts {
+        start := text.index(scope, line)
+        matches = append(matches, {begin: start, end: start + len(line)})
+      }
+      if num_callouts == num_codeblock_callouts {
+        num_callouts = 0
+        num_codeblock_callouts = 0
+      }
+    }
+  }

--- a/scripts/MatchingNumberedCallouts.tengo
+++ b/scripts/MatchingNumberedCallouts.tengo
@@ -1,7 +1,7 @@
 /*
 Tengo Language
-Checks that dot callouts (<.>) are matching 
-$ tengo MatchingDotCallouts.tengo <asciidoc_file_to_validate>
+Checks that numbered callouts (<\d+>) are matching 
+$ tengo MatchingNumberedCallouts.tengo <asciidoc_file_to_validate>
 */
 
 fmt := import("fmt")
@@ -14,19 +14,19 @@ matches := []
 
 num_codeblock_callouts := 0
 num_callouts := 0
-codeblock_callout_regex := ".+<(\\.)>"
-callout_regex := "^<(\\.)>"
+codeblock_callout_regex := ".+( <\\d+>)+"
+callout_regex := "^<(\\d+)>"
 
 for line in text.split(scope, "\n") {
   if text.re_match(codeblock_callout_regex, line) {
     //restart for new listingblock
     num_callouts = 0
     //account for lines with multiple callouts
-    num_callouts_in_line := text.count(line, "<.>")
-    if num_callouts_in_line > 1 {
-      num_codeblock_callouts = num_codeblock_callouts + num_callouts_in_line
-    } else {
-      num_codeblock_callouts++
+    for i := 1; i < len(line); i++ {
+      //text.count must be str, not regex
+      str := "<" + i + ">"
+      num_callouts_in_line := text.count(line, str)
+      num_codeblock_callouts += num_callouts_in_line
     }
   }
 
@@ -43,9 +43,8 @@ for line in text.split(scope, "\n") {
   }
 }
 
-
 if len(matches) == 0 {  
-  fmt.println("Dot callouts are balanced")
+  fmt.println("Numbered callouts are balanced")
 } else {
   fmt.println(matches) 
 }


### PR DESCRIPTION
Reports an error if a numbered callout outside the listing block is not found inside the listing block.