### PR TITLE
Rule checker syntax fixes

### DIFF
--- a/scripts/validate-vale-rules.sh
+++ b/scripts/validate-vale-rules.sh
@@ -13,11 +13,11 @@ set -e
 
 Rule() {
     DIR=".vale/fixtures/$RULE"
-    echo $DIR
+    echo "$DIR"
     VALIDALERTSCOUNT="$(vale --config="$DIR/.vale.ini" --no-exit --output=line "$DIR/testvalid.adoc" | wc -l)"
     INVALIDALERTSCOUNT="$(vale --config="$DIR/.vale.ini" --no-exit --output=line "$DIR/testinvalid.adoc" | wc -l)"
     INVALIDLINES="$(grep -c "//vale-fixture" "$DIR/testinvalid.adoc" || true)"
-    INVALIDGAP=$(($INVALIDLINES - $INVALIDALERTSCOUNT))
+    INVALIDGAP=$((INVALIDLINES - INVALIDALERTSCOUNT))
     if [ "$VALIDALERTSCOUNT" -gt 0 ]
     then
         echo "$VALIDALERTSCOUNT ERROR(s) in $DIR/testvalid.adoc for .vale/styles/$RULE.yml"


### PR DESCRIPTION
The tools/validate-shell-scripts.sh in the VRH repo flags these errors in our AsciiDoc rule checker and blocks the AsciiDoc PR. Fixing here and in the AsciiDoc PR