### PR TITLE
Fix vale error

### DIFF
--- a/.vale/styles/AsciiDoc/ImageContainsAltText.yml
+++ b/.vale/styles/AsciiDoc/ImageContainsAltText.yml
@@ -1,7 +1,6 @@
 ---
 extends: existence
 scope: raw
-ignorecase: true
 level: error
 link: https://redhat-documentation.github.io/supplementary-style-guide/#cloud-services-images
 message: "Image is missing accessibility alt tags."

--- a/.vale/styles/AsciiDoc/MatchingDotCallouts.yml
+++ b/.vale/styles/AsciiDoc/MatchingDotCallouts.yml
@@ -1,6 +1,5 @@
 ---
 extends: script
-ignorecase: true
 message: "Corresponding callout not found."
 level: error
 link: https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/

--- a/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
@@ -1,6 +1,5 @@
 ---
 extends: script
-ignorecase: true
 message: "Numbered callout does not follow sequentially."
 level: error
 link: https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/

--- a/.vale/styles/AsciiDoc/ValidAdmonitionBlocks.yml
+++ b/.vale/styles/AsciiDoc/ValidAdmonitionBlocks.yml
@@ -1,6 +1,5 @@
 ---
 extends: script
-ignorecase: true
 level: error
 message: "Unterminated admonition block found in file."
 link: https://docs.asciidoctor.org/asciidoc/latest/blocks/admonitions/

--- a/.vale/styles/AsciiDoc/ValidCodeBlocks.yml
+++ b/.vale/styles/AsciiDoc/ValidCodeBlocks.yml
@@ -1,6 +1,5 @@
 ---
 extends: script
-ignorecase: true
 level: error
 message: "Unterminated listing block found in file."
 link: https://docs.asciidoctor.org/asciidoc/latest/verbatim/listing-blocks/

--- a/.vale/styles/AsciiDoc/ValidConditions.yml
+++ b/.vale/styles/AsciiDoc/ValidConditions.yml
@@ -1,6 +1,5 @@
 ---
 extends: script
-ignorecase: true
 level: error
 message: "File contains unbalanced if statements."
 link: https://docs.asciidoctor.org/asciidoc/latest/directives/ifdef-ifndef/

--- a/.vale/styles/AsciiDoc/ValidTableBlocks.yml
+++ b/.vale/styles/AsciiDoc/ValidTableBlocks.yml
@@ -1,6 +1,5 @@
 ---
 extends: script
-ignorecase: true
 level: error
 message: "Unterminated table block found in file."
 link: https://docs.asciidoctor.org/asciidoc/latest/tables/build-a-basic-table/

--- a/.vale/styles/OpenShiftAsciiDoc/AdditionalResourcesHeadingHasRoleID.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/AdditionalResourcesHeadingHasRoleID.yml
@@ -1,7 +1,6 @@
 ---
 extends: existence
 scope: raw
-ignorecase: true
 level: suggestion
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#additional-resources-sections
 message: "Additional resources heading is missing the \"_additional-resources\" role attribute declaration"

--- a/.vale/styles/OpenShiftAsciiDoc/CheckDollarSymbolInTerminalBlock.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/CheckDollarSymbolInTerminalBlock.yml
@@ -1,7 +1,6 @@
 ---
 extends: existence
 scope: raw
-ignorecase: true
 level: error
 link: https://redhat-documentation.github.io/supplementary-style-guide/#commands-with-root-privileges
 message: "Terminal code block missing a command prompt at the beginning of the line. For example output, prepend the code block with '.Example output'."

--- a/.vale/styles/OpenShiftAsciiDoc/IdHasContextVariable.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/IdHasContextVariable.yml
@@ -1,7 +1,6 @@
 ---
 extends: existence
 scope: raw
-ignorecase: true
 level: error
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#anchoring-in-module-files
 message: "ID is missing the \"_{context}\" variable at the end of the ID."

--- a/.vale/styles/OpenShiftAsciiDoc/ModuleContainsContentType.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/ModuleContainsContentType.yml
@@ -1,7 +1,6 @@
 ---
 extends: occurrence
 scope: raw
-ignorecase: true
 level: error
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#module-file-metadata
 message: "Module is missing the \"_content-type\" variable."

--- a/.vale/styles/OpenShiftAsciiDoc/ModuleContainsParentAssemblyComment.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/ModuleContainsParentAssemblyComment.yml
@@ -1,7 +1,6 @@
 ---
 extends: occurrence
 scope: raw
-ignorecase: true
 level: suggestion
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#module-file-metadata
 message: "The comment at the beginning of the module that lists the parent assembly is missing."

--- a/.vale/styles/OpenShiftAsciiDoc/NoNestingInModules.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/NoNestingInModules.yml
@@ -1,7 +1,6 @@
 ---
 extends: existence
 scope: raw
-ignorecase: true
 level: error
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#links-hyperlinks-and-cross-references
 message: "You can only nest snippets or Git Hub raw user content in modules."

--- a/.vale/styles/OpenShiftAsciiDoc/NoXrefInModules.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/NoXrefInModules.yml
@@ -1,7 +1,6 @@
 ---
 extends: existence
 scope: raw
-ignorecase: true
 level: error
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#links-hyperlinks-and-cross-references
 message: "Do not include xrefs in modules, only assemblies."

--- a/.vale/styles/OpenShiftAsciiDoc/XrefContainsAnchorID.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/XrefContainsAnchorID.yml
@@ -1,7 +1,6 @@
 ---
 extends: existence
 scope: raw
-ignorecase: true
 level: error
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#links-hyperlinks-and-cross-references
 message: "The xref is missing an anchor ID."

--- a/.vale/styles/OpenShiftAsciiDoc/XrefContainsHTML.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/XrefContainsHTML.yml
@@ -1,7 +1,6 @@
 ---
 extends: existence
 scope: raw
-ignorecase: true
 level: error
 link: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#links-hyperlinks-and-cross-references
 message: "Use .adoc instead of .html in xrefs"

--- a/.vale/styles/OpenShiftAsciiDoc/XrefMustNotHaveNakedLabel.yml
+++ b/.vale/styles/OpenShiftAsciiDoc/XrefMustNotHaveNakedLabel.yml
@@ -1,7 +1,6 @@
 ---
 extends: existence
 scope: raw
-ignorecase: true
 level: suggestion
 link: https://redhat-documentation.github.io/supplementary-style-guide/#link-text
 message: "The xref is missing link text."


### PR DESCRIPTION
`scope: raw` files cannot uses `ignorecase:true` for Vale 2.24.4+

```
Validating language usage in added or modified AsciiDoc files with vale version 2.24.4
E201 Invalid value [/home/aireilly/openshift-docs/.vale/styles/AsciiDoc/MatchingDotCallouts.yml:3:1]:

   2  extends: script
   3* ignorecase: true
   4  message: "Corresponding callout not found."
   5  level: error

has invalid keys: 'ignorecase'

Execution stopped with code 1.
```