### PR TITLE
New AsciiDoc rules - catch unclosed attr blocks, catch unclosed id quotes 

### DIFF
--- a/.vale/fixtures/AsciiDoc/ClosedAttributeBlocks/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/ClosedAttributeBlocks/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `ClosedAttributeBlocks` rule
+StylesPath = ../../../styles
+MinAlertLevel = error
+[*.adoc]
+AsciiDoc.ClosedAttributeBlocks = YES

--- a/.vale/fixtures/AsciiDoc/ClosedAttributeBlocks/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ClosedAttributeBlocks/testinvalid.adoc
@@ -1,0 +1,9 @@
+//vale-fixture
+:_content-type: ASSEMBLY
+[id="rosa-getting-started
+= Comprehensive guide to getting started with {product-title}
+
+//vale-fixture
+:_content-type: ASSEMBLY
+[id="rosa-getting-started_{context}
+= Another guide to getting started

--- a/.vale/fixtures/AsciiDoc/ClosedAttributeBlocks/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ClosedAttributeBlocks/testvalid.adoc
@@ -1,0 +1,4 @@
+//vale-fixture
+:_content-type: ASSEMBLY
+[id="rosa-getting-started_{context}"]
+= Comprehensive guide to getting started with {product-title}

--- a/.vale/fixtures/AsciiDoc/ClosedIdQuotes/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/ClosedIdQuotes/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `ClosedIdQuotes` rule
+StylesPath = ../../../styles
+MinAlertLevel = error
+[*.adoc]
+AsciiDoc.ClosedIdQuotes = YES

--- a/.vale/fixtures/AsciiDoc/ClosedIdQuotes/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ClosedIdQuotes/testinvalid.adoc
@@ -1,0 +1,7 @@
+//vale-fixture
+[id="rosa-getting-started_{context}]
+= Comprehensive guide to getting started with {product-title}
+
+//vale-fixture
+[id="rosa-getting-started]
+= Another guide to getting started

--- a/.vale/fixtures/AsciiDoc/ClosedIdQuotes/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/ClosedIdQuotes/testvalid.adoc
@@ -1,0 +1,4 @@
+//vale-fixture
+:_content-type: ASSEMBLY
+[id="rosa-getting-started_{context}"]
+= Comprehensive guide to getting started with {product-title}

--- a/.vale/styles/AsciiDoc/ClosedAttributeBlocks.yml
+++ b/.vale/styles/AsciiDoc/ClosedAttributeBlocks.yml
@@ -1,0 +1,7 @@
+---
+extends: existence
+scope: raw
+level: error
+message: "Attribute block is not closed."
+raw:
+  - '(?<!\/\/)\[.*(?<!\])\n'

--- a/.vale/styles/AsciiDoc/ClosedIdQuotes.yml
+++ b/.vale/styles/AsciiDoc/ClosedIdQuotes.yml
@@ -1,0 +1,7 @@
+---
+extends: existence
+scope: raw
+level: error
+message: "Quoted ID value is not closed."
+raw:
+  - '(?<!\/\/)\[id\=\".*(?<!\")\]'


### PR DESCRIPTION
Sorry :p

One rules checks for open attr blocks, the other for open quotes in a ID attr block.