### PR TITLE
Allowing repeated numbers in callouts 

### DIFF
--- a/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testvalid.adoc
@@ -10,3 +10,16 @@ end
 <1> Library import
 <2> URL mapping
 <3> Response block
+
+//vale-fixture
+[source,ruby]
+----
+require 'sinatra' <1>
+
+get '/hi' do <1>
+  "Hello World!"
+end
+key: value <2>
+----
+<1> Library import
+<2> URL mapping

--- a/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
@@ -28,7 +28,7 @@ script: |
         //cast string > int
         num := text.atoi(trimmed)
         //start counting
-        if num != prev_num+1 {
+        if num != prev_num && num != prev_num+1 {
           start := text.index(scope, line)
           matches = append(matches, {begin: start, end: start + len(line)})
         }

--- a/scripts/SequentialNumberedCallouts.tengo
+++ b/scripts/SequentialNumberedCallouts.tengo
@@ -32,7 +32,7 @@ for line in text.split(scope, "\n") {
       //cast string > int
       num := text.atoi(trimmed)
       //start counting
-      if num != prev_num+1 {
+      if num != prev_num && num != prev_num+1 {
         start := text.index(scope, line)
         matches = append(matches, {begin: start, end: start + len(line)}) 
       }


### PR DESCRIPTION
... as long as overall sequence increases in value

This is ok:
````
[source,ruby]
----
require 'sinatra' <1>

get '/hi' do <1>
  "Hello World!"
end
key: value <2>
----
<1> Library import
<2> URL mapping
````

This is not:
````
[source,ruby]
----
require 'sinatra' <1>

get '/hi' do <2>
  "Hello World!"
end
key: value <1>
----
<1> Library import
<2> URL mapping
````