### PR TITLE
Tweaking regex for MatchingNumberedCallout 

### DIFF
--- a/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/testvalid.adoc
@@ -10,3 +10,17 @@ end
 <1> Library import
 <2> URL mapping
 <3> Response block
+
+//vale-fixture
+[source,ruby]
+----
+require 'sinatra' \\//<1>
+
+get '/hi' do <2><3>
+  "Hello World!"<4>
+end
+----
+<1> Library import
+<2> URL mapping
+<3> Response block
+<4> Hi

--- a/.vale/styles/AsciiDoc/MatchingNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/MatchingNumberedCallouts.yml
@@ -15,7 +15,7 @@ script: |
 
   num_codeblock_callouts := 0
   num_callouts := 0
-  codeblock_callout_regex := ".*( <\\d+>)+"
+  codeblock_callout_regex := ".(<\\d+>)+"
   callout_regex := "^<(\\d+)>"
 
   for line in text.split(scope, "\n") {

--- a/scripts/MatchingNumberedCallouts.tengo
+++ b/scripts/MatchingNumberedCallouts.tengo
@@ -19,13 +19,14 @@ scope += "\n"
 
 num_codeblock_callouts := 0
 num_callouts := 0
-codeblock_callout_regex := ".*( <\\d+>)+"
+codeblock_callout_regex := ".(<\\d+>)+"
 callout_regex := "^<(\\d+)>"
 
 for line in text.split(scope, "\n") {
   if text.re_match(codeblock_callout_regex, line) {
     //restart for new listingblock
     num_callouts = 0
+    fmt.println(line)
     //account for lines with multiple callouts
     for i := 1; i < len(line); i++ {
       //text.count must be str, not regex


### PR DESCRIPTION
Removing space in regex as this wasn't catching instances where there was no space before the callout, for example //<1>

However, callouts outside of the codeblock that appear at the start of the line were then included in the counting, so changed `.*` to `.` and this excludes these callouts. Not 100% sure of the logic why... 