### PR TITLE
fixes vale.ini error level

### DIFF
--- a/.vale/fixtures/AsciiDoc/ClosedAttributeBlocks/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/ClosedAttributeBlocks/.vale.ini
@@ -1,5 +1,5 @@
 ; Vale configuration file to test the `ClosedAttributeBlocks` rule
 StylesPath = ../../../styles
-MinAlertLevel = error
+MinAlertLevel = suggestion
 [*.adoc]
 AsciiDoc.ClosedAttributeBlocks = YES

--- a/.vale/fixtures/AsciiDoc/ClosedIdQuotes/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/ClosedIdQuotes/.vale.ini
@@ -1,5 +1,5 @@
 ; Vale configuration file to test the `ClosedIdQuotes` rule
 StylesPath = ../../../styles
-MinAlertLevel = error
+MinAlertLevel = suggestion
 [*.adoc]
 AsciiDoc.ClosedIdQuotes = YES

--- a/.vale/fixtures/AsciiDoc/MatchingDotCallouts/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/MatchingDotCallouts/.vale.ini
@@ -1,5 +1,5 @@
 ; Vale configuration file to test the `SequentialNumberedCallouts` rule
 StylesPath = ../../../styles
-MinAlertLevel = error
+MinAlertLevel = suggestion
 [*.adoc]
 AsciiDoc.MatchingDotCallouts = YES

--- a/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/MatchingNumberedCallouts/.vale.ini
@@ -1,5 +1,5 @@
 ; Vale configuration file to test the `SequentialNumberedCallouts` rule
 StylesPath = ../../../styles
-MinAlertLevel = error
+MinAlertLevel = suggestion
 [*.adoc]
 AsciiDoc.MatchingNumberedCallouts = YES

--- a/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/.vale.ini
@@ -1,5 +1,5 @@
 ; Vale configuration file to test the `SequentialNumberedCallouts` rule
 StylesPath = ../../../styles
-MinAlertLevel = error
+MinAlertLevel = suggestion
 [*.adoc]
 AsciiDoc.SequentialNumberedCallouts = YES

--- a/.vale/fixtures/AsciiDoc/ValidAdmonitionBlocks/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/ValidAdmonitionBlocks/.vale.ini
@@ -1,5 +1,5 @@
 ; Vale configuration file to test the `ValidAdmonitionBlocks` rule
 StylesPath = ../../../styles
-MinAlertLevel = error
+MinAlertLevel = suggestion
 [*.adoc]
 AsciiDoc.ValidAdmonitionBlocks = YES

--- a/.vale/fixtures/AsciiDoc/ValidCodeBlocks/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/ValidCodeBlocks/.vale.ini
@@ -1,5 +1,5 @@
 ; Vale configuration file to test the `ValidConditions` rule
 StylesPath = ../../../styles
-MinAlertLevel = error
+MinAlertLevel = suggestion
 [*.adoc]
 AsciiDoc.ValidCodeBlocks = YES

--- a/.vale/fixtures/AsciiDoc/ValidConditions/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/ValidConditions/.vale.ini
@@ -1,5 +1,5 @@
 ; Vale configuration file to test the `ValidConditions` rule
 StylesPath = ../../../styles
-MinAlertLevel = error
+MinAlertLevel = suggestion
 [*.adoc]
 AsciiDoc.ValidConditions = YES

--- a/.vale/fixtures/AsciiDoc/ValidTableBlocks/.vale.ini
+++ b/.vale/fixtures/AsciiDoc/ValidTableBlocks/.vale.ini
@@ -1,5 +1,5 @@
 ; Vale configuration file to test the `ValidConditions` rule
 StylesPath = ../../../styles
-MinAlertLevel = error
+MinAlertLevel = suggestion
 [*.adoc]
 AsciiDoc.ValidTableBlocks = YES

--- a/.vale/styles/AsciiDoc/ImageContainsAltText.yml
+++ b/.vale/styles/AsciiDoc/ImageContainsAltText.yml
@@ -1,7 +1,7 @@
 ---
 extends: existence
 scope: raw
-level: error
+level: warning
 link: https://redhat-documentation.github.io/supplementary-style-guide/#cloud-services-images
 message: "Image is missing accessibility alt tags."
 raw:

--- a/.vale/styles/AsciiDoc/MatchingDotCallouts.yml
+++ b/.vale/styles/AsciiDoc/MatchingDotCallouts.yml
@@ -1,7 +1,7 @@
 ---
 extends: script
 message: "Corresponding callout not found."
-level: error
+level: warning
 link: https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/
 scope: raw
 script: |

--- a/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
@@ -1,7 +1,7 @@
 ---
 extends: script
 message: "Numbered callout does not follow sequentially."
-level: error
+level: warning
 link: https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/
 scope: raw
 script: |


### PR DESCRIPTION
* ImageContainsAltText.yml          - warning
* SequentialNumberedCallouts.yml    - warning
* MatchingDotCallouts.yml           - warning
* MatchingNumberedCallouts.yml      - warning
* ClosedAttributeBlocks.yml         - error
* ValidAdmonitionBlocks.yml         - error
* ValidTableBlocks.yml              - error
* ClosedIdQuotes.yml                - error
* ValidCodeBlocks.yml               - error
* ValidConditions.yml               - error
* Alert level should be `MinAlertLevel = suggestion` in vale.ini fixture folders. This allows for all error levels to be set in rules.