### PR TITLE
Checks if unordered callouts in a codeblock are sequential - WIP

### DIFF
--- a/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testinvalid.adoc
@@ -3,7 +3,7 @@
 require 'sinatra' <1>
 get '/hi' do <2>
 require 'sinatra' <3>
-get '/hi' do <4>
+get '/hi' do <12>
 hi there <5>
 goop <6>
 require 'sinatra'

--- a/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testvalid.adoc
@@ -3,20 +3,21 @@
 ----
 require 'sinatra' <1>
 
-get '/hi' do <2> <3>
+get '/hi' do <3>
   "Hello World!"
 end
+key: value <2>
 ----
 <1> Library import
 <2> URL mapping
-<3> Response block
+<3> test
 
 //vale-fixture
 [source,ruby]
 ----
 require 'sinatra' <1>
 
-get '/hi' do <1>
+get '/hi' do <2>
   "Hello World!"
 end
 key: value <2>

--- a/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
@@ -8,22 +8,48 @@ script: |
   text := import("text")
   matches := []
 
+  existingNumbers := []
+  numInList := false
+
   //trim extra whitespace
   scope = text.trim_space(scope)
   //add a newline, it might be missing
   scope += "\n"
 
-  prev_num := 0
   numbered_callout_regex := ".*<(\\d+)>"
   listingblock_delim_regex := "^-{4,}$"
+  found := false
+  block := false
 
   for line in text.split(scope, "\n") {
-    //reset count if we hit a listing block delimiter
+    //Check if we're in a code block
     if text.re_match(listingblock_delim_regex, line) {
-      prev_num = 0
+      if block == false {
+        block = true
+      } else if block == true {
+          block = false
+      
+          //Find if the found callout numbers in the list are sequential
+          for i in existingNumbers{
+            for j in existingNumbers{
+              numInList = false
+              if j == i+1 || j == i-1{
+                numInList = true
+                break
+              } 
+            }
+            if !numInList {
+              start := text.index(scope, line)
+              matches = append(matches, {begin: start, end: start + len(line)})
+          }
+          
+        }
+        //Then wipe list until next codeblock is found
+        existingNumbers = []
+      } 
     }
-
-    if text.re_match(numbered_callout_regex, line) {
+    
+    if text.re_match(numbered_callout_regex, line) && block == true {
       callout := text.re_find("<(\\d+)>", line)
       for key, value in callout {
         //trim angle brackets from string
@@ -31,13 +57,21 @@ script: |
         trimmed = text.trim_prefix(trimmed, "<")
         trimmed = text.trim_suffix(trimmed, ">")
         //cast string > int
-        num := text.atoi(trimmed)
-        //start counting
-        if num != prev_num && num != prev_num+1 {
-          start := text.index(scope, line)
-          matches = append(matches, {begin: start, end: start + len(line)})
+        num := text.atoi(trimmed)     
+        
+        //Check if number is in list  
+        for i in existingNumbers{   
+          found = false
+          if i == num{
+            found = true
+            break
+            }
         }
-        prev_num = num
-      }
-    }
+        
+        //If number not found in the list, add to list 
+        if !found {
+          existingNumbers = append(existingNumbers, num)  
+        } 
+      }  
+    }  
   }

--- a/scripts/SequentialNumberedCallouts.tengo
+++ b/scripts/SequentialNumberedCallouts.tengo
@@ -11,23 +11,50 @@ text := import("text")
 input := os.args()
 scope := os.read_file(input[2])
 matches := []
+existingNumbers := []
+numInList := false
 
 //trim extra whitespace
 scope = text.trim_space(scope)
 //add a newline, it might be missing
 scope += "\n"
 
-prev_num := 0
 numbered_callout_regex := ".*<(\\d+)>"
 listingblock_delim_regex := "^-{4,}$"
+found := false
+block := false
 
 for line in text.split(scope, "\n") {
-  //reset count if we hit a listing block delimiter
+  //Check if we're in a code block
   if text.re_match(listingblock_delim_regex, line) {
-    prev_num = 0
+    if block == false {
+      block = true
+    } else if block == true {
+        block = false
+    
+        //Find if the found callout numbers in the list are sequential
+        for i in existingNumbers{
+          for j in existingNumbers{
+            numInList = false
+            if j == i+1 || j == i-1{
+              fmt.println(i,j, "Numbers are in sequence")
+              numInList = true
+              break
+            } 
+          }
+          if !numInList {
+            fmt.println( "This is out of sequence")
+            start := text.index(scope, line)
+            matches = append(matches, {begin: start, end: start + len(line)})
+        }
+        
+      }
+      //Then wipe list until next codeblock is found
+      existingNumbers = []
+    } 
   }
-
-  if text.re_match(numbered_callout_regex, line) {
+  
+  if text.re_match(numbered_callout_regex, line) && block == true {
     callout := text.re_find("<(\\d+)>", line)
     for key, value in callout {
       //trim angle brackets from string
@@ -35,16 +62,25 @@ for line in text.split(scope, "\n") {
       trimmed = text.trim_prefix(trimmed, "<")
       trimmed = text.trim_suffix(trimmed, ">")
       //cast string > int
-      num := text.atoi(trimmed)
-      //start counting
-      if num != prev_num && num != prev_num+1 {
-        start := text.index(scope, line)
-        matches = append(matches, {begin: start, end: start + len(line)})
+      num := text.atoi(trimmed)     
+      
+      //Check if number is in list  
+      for i in existingNumbers{   
+        found = false
+        if i == num{
+          found = true
+          break
+          }
       }
-      prev_num = num
-    }
-  }
+      
+      //If number not found in the list, add to list 
+      if !found {
+        existingNumbers = append(existingNumbers, num)  
+      } 
+    }  
+  }  
 }
+
 
 if len(matches) == 0 {
   fmt.println("Callouts are sequential")


### PR DESCRIPTION
WIP - An attempt to satisfy these scenarios where a callout number is repeated elsewhere in codeblock. It should still fire if a callout misses a sequential number overall.

````
//vale-fixture
[source,ruby]
----
require 'sinatra' <1>

get '/hi' do <3>
  "Hello World!"
end
key: value <2>
----
<1> Library import
<2> URL mapping
<3> test

//vale-fixture
[source,ruby]
----
require 'sinatra' <1>

get '/hi' do <2>
  "Hello World!"
end
key: value <2>
----
<1> Library import
<2> URL mapping

````