### PR TITLE
Tweaks the callout rules

### DIFF
--- a/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testinvalid.adoc
+++ b/.vale/fixtures/AsciiDoc/SequentialNumberedCallouts/testinvalid.adoc
@@ -19,13 +19,3 @@ get '/hi' do <7> <8>
 <6> Again, some text
 <7> Moar text
 <8> Again, some more text
-
-//vale-fixture
-[source,ruby]
-----
-require 'sinatra' <1>
-get '/hi' do <3>
-get '/hi' do <4>
-----
-<1> Test
-<2> Test

--- a/.vale/styles/AsciiDoc/MatchingNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/MatchingNumberedCallouts.yml
@@ -1,6 +1,6 @@
 ---
 extends: script
-message: "Missing numbered callout."
+message: "Corresponding callout not found."
 level: error
 link: https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/
 scope: raw

--- a/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
+++ b/.vale/styles/AsciiDoc/SequentialNumberedCallouts.yml
@@ -14,7 +14,7 @@ script: |
   scope += "\n"
 
   prev_num := 0
-  numbered_callout_regex := ".*<(\\d+)>"
+  callout_regex := "^<(\\d+)>"
   listingblock_delim_regex := "^-{4,}$"
 
   for line in text.split(scope, "\n") {
@@ -23,7 +23,7 @@ script: |
       prev_num = 0
     }
 
-    if text.re_match(numbered_callout_regex, line) {
+    if text.re_match(callout_regex, line) {
       callout := text.re_find("<(\\d+)>", line)
       for key, value in callout {
         //trim angle brackets from string
@@ -33,7 +33,7 @@ script: |
         //cast string > int
         num := text.atoi(trimmed)
         //start counting
-        if num != prev_num && num != prev_num+1 {
+        if num != prev_num+1 {
           start := text.index(scope, line)
           matches = append(matches, {begin: start, end: start + len(line)})
         }

--- a/scripts/SequentialNumberedCallouts.tengo
+++ b/scripts/SequentialNumberedCallouts.tengo
@@ -1,6 +1,6 @@
 /*
     Tengo Language
-    Checks that callouts are sequential 
+    Checks that callouts outside the listing block are sequential 
     $ tengo SequentialNumberedCallouts.tengo <asciidoc_file_to_validate>
 */
 
@@ -18,7 +18,7 @@ scope = text.trim_space(scope)
 scope += "\n"
 
 prev_num := 0
-numbered_callout_regex := ".*<(\\d+)>"
+callout_regex := "^<(\\d+)>"
 listingblock_delim_regex := "^-{4,}$"
 
 for line in text.split(scope, "\n") {
@@ -27,7 +27,7 @@ for line in text.split(scope, "\n") {
     prev_num = 0
   }
 
-  if text.re_match(numbered_callout_regex, line) {
+  if text.re_match(callout_regex, line) {
     callout := text.re_find("<(\\d+)>", line)
     for key, value in callout {
       //trim angle brackets from string
@@ -37,7 +37,7 @@ for line in text.split(scope, "\n") {
       //cast string > int
       num := text.atoi(trimmed)
       //start counting
-      if num != prev_num && num != prev_num+1 {
+      if num != prev_num+1 {
         start := text.index(scope, line)
         matches = append(matches, {begin: start, end: start + len(line)})
       }


### PR DESCRIPTION
This tweak adjusts some descriptions and changes how the seq callouts rulwe works. Now, it only fires for non-sequential callouts outside the listing block. 